### PR TITLE
fix: Use source and target compatibility instead of Java toolchains

### DIFF
--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
Closes #96.